### PR TITLE
Fix laravel route caching

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,42 +1,15 @@
 <?php
 
-use Kompo\Routing\Dispatcher;
+use Kompo\Http\Controllers\DispatchController;
+use Kompo\Http\Controllers\LocaleController;
 
-Route::middleware('web')->get('_kompo', function(){
-	return Dispatcher::dispatchConnection();
-})->name('_kompo');
+Route::middleware('web')->group(function() {
+    Route::get('_kompo', DispatchController::class)->name('_kompo');
+    Route::post('_kompo', DispatchController::class)->name('_kompo.post');
+    Route::put('_kompo', DispatchController::class)->name('_kompo.put');
+    Route::delete('_kompo', DispatchController::class)->name('_kompo.delete');
 
-Route::middleware('web')->post('_kompo', function(){
-	return Dispatcher::dispatchConnection();
-})->name('_kompo.post');
-
-Route::middleware('web')->put('_kompo', function(){
-	return Dispatcher::dispatchConnection();
-})->name('_kompo.put');
-
-Route::middleware('web')->delete('_kompo', function(){
-	return Dispatcher::dispatchConnection();
-})->name('_kompo.delete');
-
-
-Route::middleware('web')->group(function(){
-
-	/*
-	Route::get('kompo/keep-alive', function(){
-		return response(null, 204);
-	})->name('kompo.keep-alive');*/
-
-	if(count(config('kompo.locales')))
-
-		Route::get('set-locale/{locale?}', function ( $locale = 'en' ) {
-		    
-		    if(!array_key_exists($locale, config('kompo.locales') )) 
-		    	$locale = config('app.locale');
-
-		    \Cookie::queue('locale', $locale);
-		    
-		    return redirect()->back();
-		
-		})->name('setLocale');
-
+    if (count(config('kompo.locales'))) {
+        Route::get('set-locale/{locale?}', LocaleController::class)->name('setLocale');
+    }
 });

--- a/src/Http/Controllers/DispatchController.php
+++ b/src/Http/Controllers/DispatchController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kompo\Http\Controllers;
+
+use Kompo\Routing\Dispatcher;
+
+class DispatchController
+{
+    public function __invoke()
+    {
+        return Dispatcher::dispatchConnection();
+    }
+}

--- a/src/Http/Controllers/LocaleController.php
+++ b/src/Http/Controllers/LocaleController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kompo\Http\Controllers;
+
+class LocaleController
+{
+    public function __invoke($locale = 'en')
+    {
+        if(!array_key_exists($locale, config('kompo.locales') ))
+            $locale = config('app.locale');
+
+        \Cookie::queue('locale', $locale);
+
+        return redirect()->back();
+    }
+}


### PR DESCRIPTION
# Description
Currently php artisan route:cache fails due closure definition. Kompo shouldn't break route caching logic

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)