### PR TITLE
Adding the support into Forms to use Facades

### DIFF
--- a/src/Komponents/Form/HasModel.php
+++ b/src/Komponents/Form/HasModel.php
@@ -42,7 +42,7 @@ trait HasModel
             return;
         }
 
-        $model = $model instanceof KompoModelFacade ? $model::getClass() : $model;
+        $model = is_subclass_of($model, KompoModelFacade::class) ? $model::getClass() : $model;
 
         $this->model = $model instanceof Model ? $model : (
             $this->modelKey() ? $model::findOrNew($this->modelKey()) : new $model

--- a/src/Komponents/Form/HasModel.php
+++ b/src/Komponents/Form/HasModel.php
@@ -3,6 +3,7 @@
 namespace Kompo\Komponents\Form;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Facade;
 
 trait HasModel
 {
@@ -40,6 +41,8 @@ trait HasModel
         if (is_null($model)) {
             return;
         }
+
+        $model = $model instanceof KompoModelFacade ? $model::getClass() : $model;
 
         $this->model = $model instanceof Model ? $model : (
             $this->modelKey() ? $model::findOrNew($this->modelKey()) : new $model

--- a/src/Komponents/Form/KompoModelFacade.php
+++ b/src/Komponents/Form/KompoModelFacade.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kompo\Komponents\Form;
+
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class KompoModelFacade extends Facade
+{
+    abstract protected static function getModelBindKey();
+
+    protected static function getFacadeAccessor()
+    {
+        $bindKey = static::getModelBindKey();
+
+        if(!(static::resolveFacadeInstance($bindKey) instanceof Model)) {
+            throw new \Exception("The model bind key must be an instance of Illuminate\Database\Eloquent\Model");
+        }
+
+        return $bindKey;  
+    }
+
+    public static function getClass()
+    {
+        return static::getFacadeRoot()::class;
+    }
+}


### PR DESCRIPTION
Before these changes if we wanted to use Facades inside Forms we needed to do it like the next picture:
![image](https://github.com/user-attachments/assets/7f3fa7dc-7e3d-49a3-8693-f2d07fada43f)
With this push we'd be able to use this syntax:
![image](https://github.com/user-attachments/assets/21de9ff9-5c37-49b0-840a-564deec086c0)
The facade implementation:
![image](https://github.com/user-attachments/assets/e8f134b5-2002-4410-ba58-0ec5027fd3d0)
The KompoModelFacade gives the warranty that the given key has a bind with an eloquent model so we wrap a basic facade and give it restrictions to ensure its right working