### PR TITLE
Fix: Not being able to change the source using the disk() method

### DIFF
--- a/src/Usable/Img.php
+++ b/src/Usable/Img.php
@@ -17,14 +17,23 @@ class Img extends Block
      */
     protected $disk;
 
+    protected $originalSrc;
+
     protected function initialize($label)
     {
         $this->disk = config('kompo.default_storage_disk.image');
 
-        $this->alt($label); //To avoid breadking change - to deprecate in v4
-        $this->src($label);
+        $this->originalSrc = $label;
 
         parent::initialize('');
+    }
+
+    public function prepareForDisplay($komponent)
+    {
+        $this->alt($this->originalSrc); //To avoid breadking change - to deprecate in v4
+        $this->src($this->originalSrc); //To avoid breadking change - to deprecate in v4->);
+
+        return parent::prepareForDisplay($komponent);
     }
 
     //TODO Document


### PR DESCRIPTION
Issue explanation: We had an unexpected behavior when we was using disk into a _Img component. It's supposed to change the src to this new disk but how the initialization of src is into the constructor it wasn't doing anything.

Solution: I just changed the order of the execution of src method. Now it is being executed after the chain of methods (in prepareForDisplay) so it's able to get the src from the right disk